### PR TITLE
Added support for default array values

### DIFF
--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
@@ -61,7 +61,16 @@ class InputTypeGenerator(config: CodeGenConfig) : BaseDataTypeGenerator(config.p
                     is StringValue -> CodeBlock.of("\$S", defVal.value)
                     is FloatValue -> CodeBlock.of("\$L", defVal.value)
                     is EnumValue -> CodeBlock.of("\$T.\$N", typeUtils.findReturnType(it.type), defVal.name)
-                    is ArrayValue -> CodeBlock.of("java.util.Collections.emptyList()")
+                    is ArrayValue -> if(defVal.values.isEmpty()) CodeBlock.of("java.util.Collections.emptyList()") else CodeBlock.of("java.util.Arrays.asList(\$L)", defVal.values.map { v ->
+                        when(v) {
+                            is BooleanValue -> CodeBlock.of("\$L", v.isValue)
+                            is IntValue -> CodeBlock.of("\$L", v.value)
+                            is StringValue -> CodeBlock.of("\$S", v.value)
+                            is FloatValue -> CodeBlock.of("\$L", v.value)
+                            is EnumValue -> CodeBlock.of("\$L.\$N", ((it.type as ListType).type as TypeName).name, v.name)
+                            else -> ""
+                        }
+                    }.joinToString())
                     else -> CodeBlock.of("\$L", defVal)
                 }
             }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/java/DataTypeGenerator.kt
@@ -61,6 +61,7 @@ class InputTypeGenerator(config: CodeGenConfig) : BaseDataTypeGenerator(config.p
                     is StringValue -> CodeBlock.of("\$S", defVal.value)
                     is FloatValue -> CodeBlock.of("\$L", defVal.value)
                     is EnumValue -> CodeBlock.of("\$T.\$N", typeUtils.findReturnType(it.type), defVal.name)
+                    is ArrayValue -> CodeBlock.of("java.util.Collections.emptyList()")
                     else -> CodeBlock.of("\$L", defVal)
                 }
             }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -63,6 +63,16 @@ class KotlinInputTypeGenerator(private val config: CodeGenConfig, private val do
                             is StringValue -> CodeBlock.of("%S", defVal.value)
                             is FloatValue -> CodeBlock.of("%L", defVal.value)
                             is EnumValue -> CodeBlock.of("%M", MemberName(type as ClassName, defVal.name))
+                            is ArrayValue -> if(defVal.values.isEmpty()) CodeBlock.of("emptyList()") else CodeBlock.of("listOf(%L)", defVal.values.map { v ->
+                                when(v) {
+                                    is BooleanValue -> CodeBlock.of("%L", v.isValue)
+                                    is IntValue -> CodeBlock.of("%L", v.value)
+                                    is StringValue -> CodeBlock.of("%S", v.value)
+                                    is FloatValue -> CodeBlock.of("%Lf", v.value)
+                                    is EnumValue -> CodeBlock.of("%M", MemberName((type as ParameterizedTypeName).typeArguments[0] as ClassName, v.name))
+                                    else -> ""
+                                }
+                            }.joinToString())
                             else -> CodeBlock.of("%L", defVal)
                         }
                     }

--- a/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
+++ b/graphql-dgs-codegen-core/src/main/kotlin/com/netflix/graphql/dgs/codegen/generators/kotlin/KotlinDataTypeGenerator.kt
@@ -68,7 +68,7 @@ class KotlinInputTypeGenerator(private val config: CodeGenConfig, private val do
                                     is BooleanValue -> CodeBlock.of("%L", v.isValue)
                                     is IntValue -> CodeBlock.of("%L", v.value)
                                     is StringValue -> CodeBlock.of("%S", v.value)
-                                    is FloatValue -> CodeBlock.of("%Lf", v.value)
+                                    is FloatValue -> CodeBlock.of("%L", v.value)
                                     is EnumValue -> CodeBlock.of("%M", MemberName((type as ParameterizedTypeName).typeArguments[0] as ClassName, v.name))
                                     else -> ""
                                 }

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -583,6 +583,33 @@ class CodeGenTest {
     }
 
     @Test
+    fun generateInputWithDefaultValueForArray() {
+        val schema = """
+            input SomeType {
+                names: [String] = []
+            }
+        """.trimIndent()
+
+        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        assertThat(dataTypes).hasSize(1)
+
+        val data = dataTypes[0]
+        assertThat(data.packageName).isEqualTo(typesPackageName)
+
+        val type = data.typeSpec
+        assertThat(type.name).isEqualTo("SomeType")
+
+        val fields = type.fieldSpecs
+        assertThat(fields).hasSize(1)
+
+        val colorField = fields[0]
+        assertThat(colorField.name).isEqualTo("names")
+        assertThat(colorField.initializer.toString()).isEqualTo("java.util.Collections.emptyList()")
+
+         assertCompiles(dataTypes)
+    }
+
+    @Test
     fun generateToInputStringMethodForInputTypes() {
 
         val schema = """

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/CodeGenTest.kt
@@ -610,6 +610,92 @@ class CodeGenTest {
     }
 
     @Test
+    fun generateInputWithDefaultStringValueForArray() {
+        val schema = """
+            input SomeType {
+                names: [String] = ["A", "B"]
+            }
+        """.trimIndent()
+
+        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        assertThat(dataTypes).hasSize(1)
+
+        val data = dataTypes[0]
+        assertThat(data.packageName).isEqualTo(typesPackageName)
+
+        val type = data.typeSpec
+        assertThat(type.name).isEqualTo("SomeType")
+
+        val fields = type.fieldSpecs
+        assertThat(fields).hasSize(1)
+
+        val colorField = fields[0]
+        assertThat(colorField.name).isEqualTo("names")
+        assertThat(colorField.initializer.toString()).isEqualTo("""java.util.Arrays.asList("A", "B")""")
+
+         assertCompiles(dataTypes)
+    }
+
+    @Test
+    fun generateInputWithDefaultIntValueForArray() {
+        val schema = """
+            input SomeType {
+                numbers: [Int] = [1, 2, 3]
+            }
+        """.trimIndent()
+
+        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName)).generate() as CodeGenResult
+        assertThat(dataTypes).hasSize(1)
+
+        val data = dataTypes[0]
+        assertThat(data.packageName).isEqualTo(typesPackageName)
+
+        val type = data.typeSpec
+        assertThat(type.name).isEqualTo("SomeType")
+
+        val fields = type.fieldSpecs
+        assertThat(fields).hasSize(1)
+
+        val colorField = fields[0]
+        assertThat(colorField.name).isEqualTo("numbers")
+        assertThat(colorField.initializer.toString()).isEqualTo("""java.util.Arrays.asList(1, 2, 3)""")
+
+         assertCompiles(dataTypes)
+    }
+
+    @Test
+    fun generateInputWithDefaultEnumValueForArray() {
+        val schema = """
+            input SomeType {
+                colors: [Color] = [red]
+            }
+            
+            enum Color {
+                red,
+                blue
+            }
+        """.trimIndent()
+
+        val (dataTypes,_, enumTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, writeToFiles = true)).generate() as CodeGenResult
+        assertThat(dataTypes).hasSize(1)
+
+        val data = dataTypes[0]
+        assertThat(data.packageName).isEqualTo(typesPackageName)
+
+        val type = data.typeSpec
+        assertThat(type.name).isEqualTo("SomeType")
+
+        val fields = type.fieldSpecs
+        assertThat(fields).hasSize(1)
+
+        val colorField = fields[0]
+        assertThat(colorField.name).isEqualTo("colors")
+        assertThat(colorField.initializer.toString()).isEqualTo("""java.util.Arrays.asList(Color.red)""")
+
+         assertCompiles(dataTypes + enumTypes)
+    }
+
+    @Test
     fun generateToInputStringMethodForInputTypes() {
 
         val schema = """

--- a/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
+++ b/graphql-dgs-codegen-core/src/test/kotlin/com/netflix/graphql/dgs/codegen/KotlinCodeGenTest.kt
@@ -551,6 +551,196 @@ class KotlinCodeGenTest {
     }
 
     @Test
+    fun generateInputWithEmptyDefaultValueForArray() {
+        val schema = """
+            input SomeType {
+                names: [String!]! = []
+            }
+        """.trimIndent()
+
+        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        assertThat(dataTypes).hasSize(1)
+
+        val data = dataTypes[0]
+        assertThat(data.packageName).isEqualTo(typesPackageName)
+
+        val members = data.members
+        assertThat(members).hasSize(1)
+
+        val type = members[0] as TypeSpec
+        assertThat(type.name).isEqualTo("SomeType")
+
+        val ctorSpec = type.primaryConstructor
+        assertThat(ctorSpec).isNotNull
+        assertThat(ctorSpec!!.parameters).hasSize(1)
+
+        val colorParam = ctorSpec.parameters[0]
+        assertThat(colorParam.name).isEqualTo("names")
+        assertThat(colorParam.type.toString()).isEqualTo("kotlin.collections.List<kotlin.String>")
+        assertThat(colorParam.defaultValue).isNotNull
+        assertThat(colorParam.defaultValue.toString()).isEqualTo("emptyList()")
+    }
+
+    @Test
+    fun generateInputWithDefaultValueForStringArray() {
+        val schema = """
+            input SomeType {
+                names: [String!]! = ["DGS"]
+            }
+        """.trimIndent()
+
+        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        assertThat(dataTypes).hasSize(1)
+
+        val data = dataTypes[0]
+        assertThat(data.packageName).isEqualTo(typesPackageName)
+
+        val members = data.members
+        assertThat(members).hasSize(1)
+
+        val type = members[0] as TypeSpec
+        assertThat(type.name).isEqualTo("SomeType")
+
+        val ctorSpec = type.primaryConstructor
+        assertThat(ctorSpec).isNotNull
+        assertThat(ctorSpec!!.parameters).hasSize(1)
+
+        val colorParam = ctorSpec.parameters[0]
+        assertThat(colorParam.name).isEqualTo("names")
+        assertThat(colorParam.type.toString()).isEqualTo("kotlin.collections.List<kotlin.String>")
+        assertThat(colorParam.defaultValue).isNotNull
+        assertThat(colorParam.defaultValue.toString()).isEqualTo("""listOf("DGS")""")
+    }
+
+    @Test
+    fun generateInputWithDefaultValueForNullableStringArray() {
+        val schema = """
+            input SomeType {
+                names: [String]! = ["DGS"]
+            }
+        """.trimIndent()
+
+        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        assertThat(dataTypes).hasSize(1)
+
+        val data = dataTypes[0]
+        assertThat(data.packageName).isEqualTo(typesPackageName)
+
+        val members = data.members
+        assertThat(members).hasSize(1)
+
+        val type = members[0] as TypeSpec
+        assertThat(type.name).isEqualTo("SomeType")
+
+        val ctorSpec = type.primaryConstructor
+        assertThat(ctorSpec).isNotNull
+        assertThat(ctorSpec!!.parameters).hasSize(1)
+
+        val colorParam = ctorSpec.parameters[0]
+        assertThat(colorParam.name).isEqualTo("names")
+        assertThat(colorParam.type.toString()).isEqualTo("kotlin.collections.List<kotlin.String?>")
+        assertThat(colorParam.defaultValue).isNotNull
+        assertThat(colorParam.defaultValue.toString()).isEqualTo("""listOf("DGS")""")
+    }
+
+    @Test
+    fun generateInputWithDefaultValueForIntArray() {
+        val schema = """
+            input SomeType {
+                names: [Int!]! = [1,2,3]
+            }
+        """.trimIndent()
+
+        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        assertThat(dataTypes).hasSize(1)
+
+        val data = dataTypes[0]
+        assertThat(data.packageName).isEqualTo(typesPackageName)
+
+        val members = data.members
+        assertThat(members).hasSize(1)
+
+        val type = members[0] as TypeSpec
+        assertThat(type.name).isEqualTo("SomeType")
+
+        val ctorSpec = type.primaryConstructor
+        assertThat(ctorSpec).isNotNull
+        assertThat(ctorSpec!!.parameters).hasSize(1)
+
+        val colorParam = ctorSpec.parameters[0]
+        assertThat(colorParam.name).isEqualTo("names")
+        assertThat(colorParam.type.toString()).isEqualTo("kotlin.collections.List<kotlin.Int>")
+        assertThat(colorParam.defaultValue).isNotNull
+        assertThat(colorParam.defaultValue.toString()).isEqualTo("""listOf(1, 2, 3)""")
+    }
+
+    @Test
+    fun generateInputWithDefaultValueForEnumArray() {
+        val schema = """
+            input SomeType {
+                colors: [Color!]! = [red]
+            }
+            
+            enum Color {
+                red,
+                blue
+            }
+        """.trimIndent()
+
+        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        assertThat(dataTypes).hasSize(1)
+
+        val data = dataTypes[0]
+        assertThat(data.packageName).isEqualTo(typesPackageName)
+
+        val members = data.members
+        assertThat(members).hasSize(1)
+
+        val type = members[0] as TypeSpec
+        assertThat(type.name).isEqualTo("SomeType")
+
+        val ctorSpec = type.primaryConstructor
+        assertThat(ctorSpec).isNotNull
+        assertThat(ctorSpec!!.parameters).hasSize(1)
+
+        val colorParam = ctorSpec.parameters[0]
+        assertThat(colorParam.name).isEqualTo("colors")
+        assertThat(colorParam.type.toString()).isEqualTo("kotlin.collections.List<com.netflix.graphql.dgs.codegen.tests.generated.types.Color>")
+        assertThat(colorParam.defaultValue).isNotNull
+        assertThat(colorParam.defaultValue.toString()).isEqualTo("""listOf(com.netflix.graphql.dgs.codegen.tests.generated.types.Color.red)""")
+    }
+
+    @Test
+    fun generateInputWithDefaultValueForBooleanArray() {
+        val schema = """
+            input SomeType {
+                booleans: [Bool!]! = [true]
+            }          
+        """.trimIndent()
+
+        val (dataTypes) = CodeGen(CodeGenConfig(schemas = setOf(schema), packageName = basePackageName, language = Language.KOTLIN)).generate() as KotlinCodeGenResult
+        assertThat(dataTypes).hasSize(1)
+
+        val data = dataTypes[0]
+        assertThat(data.packageName).isEqualTo(typesPackageName)
+
+        val members = data.members
+        assertThat(members).hasSize(1)
+
+        val type = members[0] as TypeSpec
+        assertThat(type.name).isEqualTo("SomeType")
+
+        val ctorSpec = type.primaryConstructor
+        assertThat(ctorSpec).isNotNull
+        assertThat(ctorSpec!!.parameters).hasSize(1)
+
+        val colorParam = ctorSpec.parameters[0]
+        assertThat(colorParam.name).isEqualTo("booleans")
+        assertThat(colorParam.defaultValue).isNotNull
+        assertThat(colorParam.defaultValue.toString()).isEqualTo("""listOf(true)""")
+    }
+
+    @Test
     fun generateToStringMethodForInputTypes() {
         val schema = """
             type Query {


### PR DESCRIPTION
I found a corner case of default array values. 
Since we are still Java 8 compatible, there isn't really a nice way to initialize a List of default values, so it's always just generating `Collections.emptyList()`, which is probably by far the most use case anyway. We could consider adding a flag later to generate Java > 8 style code, but that's a separate issue.

In Kotlin it's checking the contained type, and creates either an `emptyList()` or a `listOf()`. For the latter case it re-uses the default value logic to create the right contents in the list.

